### PR TITLE
build system: require yaml-cpp version 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 # find yaml
 message(STATUS "")
 message(STATUS ">>> Setting up YAML.")
-find_package(YamlCpp 0.3.0 REQUIRED)
+find_package(YamlCpp 0.5.0 REQUIRED)
 
 set(ANTOK_LIB "antok")
 if(USE_PYTHON)


### PR DESCRIPTION
Does not compile with version 0.3.0 previously required, as some methods
of the YAML::Node class are missing. Note that the required version is
not checked against the version of yaml-cpp found.
