### PR TITLE
Fix missing include

### DIFF
--- a/src/template_plot.hpp
+++ b/src/template_plot.hpp
@@ -26,19 +26,19 @@ namespace antok {
 		             T* data2 = 0);
 
 		TemplatePlot(std::map<std::string, std::vector<long> >& cutmasks,
-                     TH1* hist_template,
-                     std::vector<T*>* data1,
-                     std::vector<T*>* data2 = 0);
+		             TH1* hist_template,
+		             std::vector<T*>* data1,
+		             std::vector<T*>* data2 = 0);
 
 		TemplatePlot(std::map<std::string, std::vector<long> >& cutmasks,
-                     TH1* hist_template,
-                     std::vector<T>* data1,
-                     std::vector<T>* data2 = 0);
+		             TH1* hist_template,
+		             std::vector<T>* data1,
+		             std::vector<T>* data2 = 0);
 
 		TemplatePlot(std::map<std::string, std::vector<long> >& cutmasks,
-                     TH1* hist_template,
-                     std::vector<std::vector<T>*>* data1,
-                     std::vector<std::vector<T>*>* data2 = 0);
+		             TH1* hist_template,
+		             std::vector<std::vector<T>*>* data1,
+		             std::vector<std::vector<T>*>* data2 = 0);
 
 		void fill(long cutmask);
 


### PR DESCRIPTION
After switching boost from 1.55 to 1.56 (I do at least not remember any other changes) antok did no longer compile due to a missing include.
