### PR TITLE
Fixed handling of plot names

### DIFF
--- a/src/initializer.cxx
+++ b/src/initializer.cxx
@@ -716,6 +716,11 @@ bool antok::Initializer::initializePlotter() {
 		}
 		std::string plotName = antok::YAMLUtils::getString(plot["Name"]);
 
+        if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-") != std::string::npos )
+        {
+            std::cerr<<"Invalid name for \"Plot\" \""<<plotName<<std::endl;
+            return false;
+        }
 		if((not((hasNodeKey(plot, "Variable") and hasNodeKey(plot, "LowerBound") and hasNodeKey(plot, "UpperBound")) or
 		       (hasNodeKey(plot, "Variables") and hasNodeKey(plot, "LowerBounds") and hasNodeKey(plot, "UpperBounds")))) or
 			not hasNodeKey(plot, "NBins"))

--- a/src/initializer.cxx
+++ b/src/initializer.cxx
@@ -716,7 +716,7 @@ bool antok::Initializer::initializePlotter() {
 		}
 		std::string plotName = antok::YAMLUtils::getString(plot["Name"]);
 
-        if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_ ") != std::string::npos )
+        if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ") != std::string::npos )
         {
             std::cerr<<"Invalid character in name for \"Plot\" \""<<plotName<<std::endl;
             return false;

--- a/src/initializer.cxx
+++ b/src/initializer.cxx
@@ -716,9 +716,9 @@ bool antok::Initializer::initializePlotter() {
 		}
 		std::string plotName = antok::YAMLUtils::getString(plot["Name"]);
 
-        if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-") != std::string::npos )
+        if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_ ") != std::string::npos )
         {
-            std::cerr<<"Invalid name for \"Plot\" \""<<plotName<<std::endl;
+            std::cerr<<"Invalid character in name for \"Plot\" \""<<plotName<<std::endl;
             return false;
         }
 		if((not((hasNodeKey(plot, "Variable") and hasNodeKey(plot, "LowerBound") and hasNodeKey(plot, "UpperBound")) or

--- a/src/initializer.cxx
+++ b/src/initializer.cxx
@@ -718,7 +718,7 @@ bool antok::Initializer::initializePlotter() {
 
         if( plotName.find_first_not_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_ ") != std::string::npos )
         {
-            std::cerr<<"Invalid character in name for \"Plot\" \""<<plotName<<std::endl;
+            std::cerr<<"Invalid character in name for \"Plot\" \""<<plotName<<"\"."<<std::endl;
             return false;
         }
 		if((not((hasNodeKey(plot, "Variable") and hasNodeKey(plot, "LowerBound") and hasNodeKey(plot, "UpperBound")) or


### PR DESCRIPTION
Plot names with invalid characters like "/" produce problems,
because it is interpreted as an additional directory. Therefore
only "normal" characters are allowed now: a-zA-Z0-9 and _ -