### PR TITLE
[plotter] Implement overriding of global plot options

### DIFF
--- a/src/generators_plots.cxx
+++ b/src/generators_plots.cxx
@@ -44,19 +44,40 @@ namespace {
 	}
 
 	void __getCutmasks(const antok::plotUtils::GlobalPlotOptions& plotOptions,
+	                   const YAML::Node& plot,
 	                   std::map<std::string, std::vector<long> >& cutmasks)
 	{
 		antok::Cutter& cutter = antok::ObjectManager::instance()->getCutter();
 		cutmasks = __mergeMaps(plotOptions.cutMasks, cutmasks);
-		if(plotOptions.plotsWithSingleCutsOff) {
+
+		if (antok::YAMLUtils::hasNodeKey(plot, "PlotsWithSingleCutsOff")) {
+			const bool plotsWithSingleCutsOff = antok::YAMLUtils::handleOnOffOption("PlotsWithSingleCutsOff", plot, plot["Name"].as<std::string>());
+			if (plotsWithSingleCutsOff) {
+				cutmasks = __mergeMaps(cutter.getCutmasksAllCutsOffSeparately(), cutmasks);
+			}
+		} else if (plotOptions.plotsWithSingleCutsOff) {
 			cutmasks = __mergeMaps(cutter.getCutmasksAllCutsOffSeparately(), cutmasks);
 		}
-		if(plotOptions.plotsWithSingleCutsOn) {
+
+		if (antok::YAMLUtils::hasNodeKey(plot, "PlotsWithSingleCutsOn")) {
+			const bool plotsWithSingleCutsOn = antok::YAMLUtils::handleOnOffOption("PlotsWithSingleCutsOn", plot, plot["Name"].as<std::string>());
+			if (plotsWithSingleCutsOn) {
+				cutmasks = __mergeMaps(cutter.getCutmasksAllCutsOnSeparately(), cutmasks);
+			}
+		} else if (plotOptions.plotsWithSingleCutsOn) {
 			cutmasks = __mergeMaps(cutter.getCutmasksAllCutsOnSeparately(), cutmasks);
 		}
-		if(plotOptions.plotsForSequentialCuts) {
+
+		if (antok::YAMLUtils::hasNodeKey(plot, "PlotsForSequentialCuts")) {
+			const bool plotsForSequentialCuts = antok::YAMLUtils::handleOnOffOption("PlotsForSequentialCuts", plot, plot["Name"].as<std::string>());
+			if (plotsForSequentialCuts) {
+				cutmasks = __mergeMaps(cutter.getWaterfallCutmasks(), cutmasks);
+			}
+
+		} else if (plotOptions.plotsForSequentialCuts) {
 			cutmasks = __mergeMaps(cutter.getWaterfallCutmasks(), cutmasks);
 		}
+
 		__cleanDuplicatesFromMap(cutmasks);
 	}
 
@@ -165,7 +186,7 @@ antok::Plot* antok::generators::generate1DPlot(const YAML::Node& plot, const ant
 			std::cerr<<"Warning: There was a problem when processing the \"CustomCuts\" in \"Plot\" \""<<plotName<<"\"."<<std::endl;
 		}
 	}
-	__getCutmasks(plotOptions, cutmasks);
+	__getCutmasks(plotOptions, plot, cutmasks);
 
 	antok::Plot* antokPlot = 0;
 
@@ -329,7 +350,7 @@ antok::Plot* antok::generators::generate2DPlot(const YAML::Node& plot, const ant
 			std::cerr<<"Warning: There was a problem when processing the \"CustomCuts\" in \"Plot\" \""<<plotName<<"\"."<<std::endl;
 		}
 	}
-	__getCutmasks(plotOptions, cutmasks);
+	__getCutmasks(plotOptions, plot, cutmasks);
 
 	antok::Plot* antokPlot = 0;
 
@@ -715,7 +736,7 @@ antok::Plot* antok::generators::generate3DPlot(const YAML::Node& plot, const ant
 			std::cerr<<"Warning: There was a problem when processing the \"CustomCuts\" in \"Plot\" \""<<plotName<<"\"."<<std::endl;
 		}
 	}
-	__getCutmasks(plotOptions, cutmasks);
+	__getCutmasks(plotOptions, plot, cutmasks);
 
 	antok::Plot* antokPlot = 0;
 

--- a/src/plotter.cxx
+++ b/src/plotter.cxx
@@ -10,6 +10,7 @@
 #include<plot.hpp>
 #include<yaml_utils.hpp>
 
+using antok::YAMLUtils::handleOnOffOption;
 
 namespace {
 	// Inserts a new bin with the given label at bin i_bos to the given histogram.
@@ -245,25 +246,6 @@ antok::plotUtils::GlobalPlotOptions::GlobalPlotOptions(const YAML::Node& optionN
 
 }
 
-bool antok::plotUtils::GlobalPlotOptions::handleOnOffOption(std::string optionName, const YAML::Node& option, std::string location) const {
-
-	using antok::YAMLUtils::hasNodeKey;
-
-	if(not hasNodeKey(option, optionName)) {
-		std::cerr<<"Warning: \""<<optionName<<"\" not found in \""<<location<<"\", switching it off"<<std::endl;
-	} else {
-		std::string optionValue = antok::YAMLUtils::getString(option[optionName]);
-		if(optionValue == "On") {
-			return true;
-		} else if (optionValue == "Off") {
-			// returning at end of function
-		} else {
-			std::cerr<<"Warning: \""<<location<<"\"'s \""<<optionName<<"\" is \""<<optionValue<<"\" instead of \"On\" or \"Off\", switching it off"<<std::endl;
-		}
-	}
-	return false;
-
-}
 
 
 

--- a/src/plotter.h
+++ b/src/plotter.h
@@ -29,8 +29,6 @@ namespace antok {
 
 		  private:
 
-			bool handleOnOffOption(std::string optionName, const YAML::Node& option, std::string location) const;
-
 		};
 
 		struct waterfallHistogramContainer {

--- a/src/yaml_utils.hpp
+++ b/src/yaml_utils.hpp
@@ -79,6 +79,26 @@ namespace antok {
 				return false;
 			}
 		}
+		inline bool handleOnOffOption(std::string optionName, const YAML::Node& option, std::string location) {
+
+			using antok::YAMLUtils::hasNodeKey;
+
+			if (not hasNodeKey(option, optionName)) {
+				std::cerr << "Warning: \"" << optionName << "\" not found in \"" << location << "\", switching it off" << std::endl;
+			} else {
+				std::string optionValue = antok::YAMLUtils::getString(option[optionName]);
+				if (optionValue == "On") {
+					return true;
+				} else if (optionValue == "Off") {
+					// returning at end of function
+				} else {
+					std::cerr << "Warning: \"" << location << "\"'s \"" << optionName << "\" is \"" << optionValue
+					        << "\" instead of \"On\" or \"Off\", switching it off" << std::endl;
+				}
+			}
+			return false;
+
+		}
 
 	}
 


### PR DESCRIPTION
PlotsWithSingleCutsOff, PlotsWithSingleCutsOn, PlotsForSequentialCuts can now be defined for each plot individually.
If they are not given, the global plot potions are used.