### PR TITLE
Update user function omega not used particles

### DIFF
--- a/user/cdreis.cxx
+++ b/user/cdreis.cxx
@@ -518,7 +518,7 @@ antok::Function* antok::user::cdreis::generateGetOmega( const YAML::Node        
                                                         std::vector<std::string> &quantityNames,
                                                         int index )
 {
-	if(quantityNames.size() > 2)
+	if(quantityNames.size() > 4)
 	{
 		std::cerr<<"Too many names for function \""<<function["Name"]<<"\"."<<std::endl;
 		return 0;

--- a/user/cdreis.cxx
+++ b/user/cdreis.cxx
@@ -552,8 +552,10 @@ antok::Function* antok::user::cdreis::generateGetOmega( const YAML::Node        
 	int* Charged1Addr = data.getAddr<int>(args[6].first);
 	int* Charged2Addr = data.getAddr<int>(args[7].first);
 
-	std::string resultOmegaLV  = quantityNames[0];
-	std::string resultAccepted = quantityNames[1];
+	std::string resultOmegaLV        = quantityNames[0];
+	std::string resultAccepted       = quantityNames[1];
+	std::string resultNotUsedPi0     = quantityNames[2];
+	std::string resultNotUsedPiMinus = quantityNames[3];
 
 	if(not data.insert<TLorentzVector>(quantityNames[0]))
 	{
@@ -564,6 +566,18 @@ antok::Function* antok::user::cdreis::generateGetOmega( const YAML::Node        
 	if(not data.insert<int>(quantityNames[1]))
 	{
 		std::cerr<<antok::Data::getVariableInsertionErrorMsg(quantityNames[1]);
+		return 0;
+	}
+
+	if(not data.insert<TLorentzVector>(quantityNames[2]))
+	{
+		std::cerr<<antok::Data::getVariableInsertionErrorMsg(quantityNames[2]);
+		return 0;
+	}
+
+	if(not data.insert<TLorentzVector>(quantityNames[3]))
+	{
+		std::cerr<<antok::Data::getVariableInsertionErrorMsg(quantityNames[3]);
 		return 0;
 	}
 
@@ -613,7 +627,9 @@ antok::Function* antok::user::cdreis::generateGetOmega( const YAML::Node        
 	                                                      Mass,
 	                                                      ResolutionOmega,
 	                                                      data.getAddr<TLorentzVector>(quantityNames[0]),
-	                                                      data.getAddr<int>           (quantityNames[1]) )
+	                                                      data.getAddr<int>           (quantityNames[1]),
+	                                                      data.getAddr<TLorentzVector>(quantityNames[2]),
+	                                                      data.getAddr<TLorentzVector>(quantityNames[3]) )
 	);
 };
 

--- a/user/cdreis_functions.hpp
+++ b/user/cdreis_functions.hpp
@@ -425,7 +425,9 @@ namespace antok {
 					          double*         Mass,
 					          double*         ResolutionOmega,
 					          TLorentzVector* resultOmega,
-					          int*            resultAccepted )
+					          int*            resultAccepted
+					          TLorentzVector* resultPi0,
+					          TLorentzVector* resultPiMinus )
 							: _Pi0_OAddr      ( Pi0_OAddr       ),
 							  _Pi0_1Addr      ( Pi0_1Addr       ),
 							  _Scattered0Addr ( Scattered0Addr  ),
@@ -437,7 +439,10 @@ namespace antok {
 							  _Mass           ( Mass            ),
 							  _ResolutionOmega( ResolutionOmega ),
 							  _resultOmega    ( resultOmega     ),
-							  _resultAccepted ( resultAccepted  ) {}
+							  _resultAccepted ( resultAccepted  ),
+							  _resultPi0      ( resultPi0       ),
+					          _resultPiMinus  ( resultPiMinus   )
+					{}
 
 					virtual ~GetOmega() {}
 
@@ -509,9 +514,11 @@ namespace antok {
 					int*            _Charge1Addr;
 					int*            _Charge2Addr;
 					double*         _Mass;
-					double*         _ResolutionOmega;
+					double*         _ResolutionOme  ga;
 					TLorentzVector* _resultOmega;
 					int*            _resultAccepted;
+					TLorentzVector* _resultPi0;
+					TLorentzVector* _resultPiMinus;
 				};
 
 				class GetECALCorrectedEnergy : public Function

--- a/user/cdreis_functions.hpp
+++ b/user/cdreis_functions.hpp
@@ -441,7 +441,7 @@ namespace antok {
 							  _resultOmega    ( resultOmega     ),
 							  _resultAccepted ( resultAccepted  ),
 							  _resultPi0      ( resultPi0       ),
-					          _resultPiMinus  ( resultPiMinus   )
+							  _resultPiMinus  ( resultPiMinus   )
 					{}
 
 					virtual ~GetOmega() {}
@@ -490,6 +490,14 @@ namespace antok {
 											// Count candidates
 											numberCandidates++;
 											(*_resultOmega) = (*pi0s[i]) + (*chargedLV[j]) + (*chargedLV[k]);
+											for( unsigned int l = 0; l < pi0s.size(); l++ )
+											{
+												if( i != l ) (*_resultPi0) = (*pi0s)[l];
+											}
+											for( unsigned int m = 0; l < chargedLV.size(); m++ )
+											{
+												if( i != l ) (*_resultPiMinus) = (*chargedLV)[m];
+											}
 										}
 									}
 								}
@@ -514,7 +522,7 @@ namespace antok {
 					int*            _Charge1Addr;
 					int*            _Charge2Addr;
 					double*         _Mass;
-					double*         _ResolutionOme  ga;
+					double*         _ResolutionOmega;
 					TLorentzVector* _resultOmega;
 					int*            _resultAccepted;
 					TLorentzVector* _resultPi0;

--- a/user/cdreis_functions.hpp
+++ b/user/cdreis_functions.hpp
@@ -425,7 +425,7 @@ namespace antok {
 					          double*         Mass,
 					          double*         ResolutionOmega,
 					          TLorentzVector* resultOmega,
-					          int*            resultAccepted
+					          int*            resultAccepted,
 					          TLorentzVector* resultPi0,
 					          TLorentzVector* resultPiMinus )
 							: _Pi0_OAddr      ( Pi0_OAddr       ),
@@ -492,11 +492,11 @@ namespace antok {
 											(*_resultOmega) = (*pi0s[i]) + (*chargedLV[j]) + (*chargedLV[k]);
 											for( unsigned int l = 0; l < pi0s.size(); l++ )
 											{
-												if( i != l ) (*_resultPi0) = (*pi0s)[l];
+												if( i != l ) (*_resultPi0) = (*pi0s[l]);
 											}
-											for( unsigned int m = 0; l < chargedLV.size(); m++ )
+											for( unsigned int m = 0; m < chargedLV.size(); m++ )
 											{
-												if( i != l ) (*_resultPiMinus) = (*chargedLV)[m];
+												if( j != m && k != m ) (*_resultPiMinus) = (*chargedLV[m]);
 											}
 										}
 									}


### PR DESCRIPTION
Extended the getOmega method: It now returns the not used particles to allow creating the correct subsystems.