### PR TITLE
[plotter] Fix bug when using ROOT < 6.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ endif()
 message(STATUS "")
 message(STATUS ">>> Setting up ROOT.")
 find_package(ROOT 5.34.04 REQUIRED)
+# ROOT version 6.00.X and 6.03.X have to be excluded, as they have no FindFixBin implementation
+if( (ROOT_MAJOR_VERSION EQUAL 6 AND ROOT_MINOR_VERSION EQUAL 00) OR 
+	(ROOT_MAJOR_VERSION EQUAL 6 AND ROOT_MINOR_VERSION EQUAL 02 AND ROOT_VERSION VERSION_LESS 6.02.05) OR
+	(ROOT_MAJOR_VERSION EQUAL 6 AND ROOT_MINOR_VERSION EQUAL 03 AND ROOT_VERSION VERSION_LESS 6.03.04) )
+	message(FATAL_ERROR "ROOT version ${ROOT_VERSION} cannot be used!")
+endif()
 
 # setup Python
 message(STATUS "")

--- a/src/plotter.cxx
+++ b/src/plotter.cxx
@@ -55,8 +55,8 @@ void antok::Plotter::addInputfileToWaterfallHistograms(const TH1D* waterfall){
 #if ROOT_VERSION_CODE > ROOT_VERSION(6,0,0)
 				int i_wp_bin = wp->histogram->GetXaxis()->FindFixBin(label);
 #else
-				wp->histogram->SetBit(ROOT.TH1.kCanRebin, false);
-				const int i_wp_bin = wp->histogram->GetXaxis()->FindBin(label);
+				wp->histogram->SetBit( TH1::kCanRebin, false);
+				int i_wp_bin = wp->histogram->GetXaxis()->FindBin(label);
 #endif
 
 				if (i_wp_bin < 1) { // can not find label from new histogram in waterfall plot


### PR DESCRIPTION
There is a specialized code only used for ROOT 5, which had a bug.
The problem was, that it was Python code.